### PR TITLE
Date time fix

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Change Log for Raygun.Aspire.Hosting.Raygun
 
+### v2.0.1
+- Fixed a bug where new exception reports would be displayed as occurring 12 hours ago if they occurred after midday UTC (because of formatting dates with 12 hour time instead of 24 hour time - losing the precision for subsequent time logic).
+
 ### v2.0.0
 - Added AI Error Resolution - Get AI suggestions to resolve exceptions via a locally running LLM in an Ollama container. This is an optional opt-in feature.
 - Fixed a bug where exception messages containing characters that can't be used in file names wouldn't persist.

--- a/src/Raygun.Aspire.Hosting.Raygun/Raygun.Aspire.Hosting.Raygun.csproj
+++ b/src/Raygun.Aspire.Hosting.Raygun/Raygun.Aspire.Hosting.Raygun.csproj
@@ -22,7 +22,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://raygun.com/platform/crash-reporting</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Raygun.Aspire.Hosting.Raygun/RaygunAspireWebAppBuilderExtensions.cs
+++ b/src/Raygun.Aspire.Hosting.Raygun/RaygunAspireWebAppBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel
     {
       var raygun = new RaygunAspireWebAppResource(name);
       return builder.AddResource(raygun)
-                    .WithAnnotation(new ContainerImageAnnotation { Image = "raygunowner/raygun-aspire-portal", Tag = "2.0.0" })
+                    .WithAnnotation(new ContainerImageAnnotation { Image = "raygunowner/raygun-aspire-portal", Tag = "2.0.1" })
                     .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", port: port, targetPort: 8080))
                     .WithVolume("raygun-data", "/app/raygun")
                     .ExcludeFromManifest()

--- a/src/RaygunAspireWebApp/RaygunAspireWebApp.csproj
+++ b/src/RaygunAspireWebApp/RaygunAspireWebApp.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RaygunAspireWebApp/Views/ErrorInstance/Details.cshtml
+++ b/src/RaygunAspireWebApp/Views/ErrorInstance/Details.cshtml
@@ -37,7 +37,7 @@
       <h2 title="@Model?.RaygunMessage?.Details?.Error?.Message" class="error-heading font-opensans--18--28--600 color--color-text-default margin-bottom--12">
         @BuildHeading(Model?.RaygunMessage?.Details?.Error?.ClassName, Model?.RaygunMessage?.Details?.Error?.Message)
       </h2>
-      <p id="occurredOnHeading" class="font-opensans--14--32--600 color--color-text-low-emphasis margin-bottom--12">@Model.RaygunMessage.OccurredOn.ToString("MM/dd/yyyy hh:mm:ss")</p>
+      <p id="occurredOnHeading" class="font-opensans--14--32--600 color--color-text-low-emphasis margin-bottom--12">@Model.RaygunMessage.OccurredOn.ToString("MM/dd/yyyy HH:mm:ss")</p>
     </div>
     
     <button id="ai-error-res-btn" class="rg margin-bottom--12" onclick="handleAIChatOpened('@Json.Serialize(@Model?.AierEnabled)')">

--- a/src/RaygunAspireWebApp/Views/ErrorInstance/Tabs/_Summary.cshtml
+++ b/src/RaygunAspireWebApp/Views/ErrorInstance/Tabs/_Summary.cshtml
@@ -48,7 +48,7 @@
 
   <div class="ei-table">
     <div class="ei-label">Occurred on</div>
-    <div id="occurredOnCell" class="ei-result">@Model.RaygunMessage.OccurredOn.ToString("MM/dd/yyyy hh:mm:ss")</div>
+    <div id="occurredOnCell" class="ei-result">@Model.RaygunMessage.OccurredOn.ToString("MM/dd/yyyy HH:mm:ss")</div>
   </div>
 
   <div class="ei-table">

--- a/src/RaygunAspireWebApp/Views/Home/_ErrorList.cshtml
+++ b/src/RaygunAspireWebApp/Views/Home/_ErrorList.cshtml
@@ -16,7 +16,7 @@
       {
         <tr class="border-bottom-width--1 border-color--color-border-elevation height--40 error-table-row">
           <td class="padding-horizontal--12 font-opensans--14--24--400"><a class="no-underline color--color-text-link width--full display--block" href="/errorinstance/details/@file.Id">@file.Name</a></td>
-          <td class="js-timestamp-cell padding-horizontal--12 font-opensans--14--24--400">@file.Timestamp.ToString("MM/dd/yyyy hh:mm:ss")</td>
+          <td class="js-timestamp-cell padding-horizontal--12 font-opensans--14--24--400">@file.Timestamp.ToString("MM/dd/yyyy HH:mm:ss")</td>
         </tr>
       }
     }


### PR DESCRIPTION
Fixed a bug where new exception reports would be displayed as occurring 12 hours ago if they occurred after midday UTC (because of formatting dates with 12 hour time instead of 24 hour time - losing the precision for subsequent time logic).