### PR TITLE
Fix when exception messages are too long to use as file name

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,5 +1,8 @@
 # Change Log for Raygun.Aspire.Hosting.Raygun
 
+### v2.0.2
+- Fixed a bug where exceptions with long message names could not be saved.
+
 ### v2.0.1
 - Fixed a bug where new exception reports would be displayed as occurring 12 hours ago if they occurred after midday UTC (because of formatting dates with 12 hour time instead of 24 hour time - losing the precision for subsequent time logic).
 

--- a/src/Raygun.Aspire.Hosting.Raygun/Raygun.Aspire.Hosting.Raygun.csproj
+++ b/src/Raygun.Aspire.Hosting.Raygun/Raygun.Aspire.Hosting.Raygun.csproj
@@ -22,7 +22,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://raygun.com/platform/crash-reporting</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Raygun.Aspire.Hosting.Raygun/RaygunAspireWebAppBuilderExtensions.cs
+++ b/src/Raygun.Aspire.Hosting.Raygun/RaygunAspireWebAppBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel
     {
       var raygun = new RaygunAspireWebAppResource(name);
       return builder.AddResource(raygun)
-                    .WithAnnotation(new ContainerImageAnnotation { Image = "raygunowner/raygun-aspire-portal", Tag = "2.0.1" })
+                    .WithAnnotation(new ContainerImageAnnotation { Image = "raygunowner/raygun-aspire-portal", Tag = "2.0.2" })
                     .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", port: port, targetPort: 8080))
                     .WithVolume("raygun-data", "/app/raygun")
                     .ExcludeFromManifest()

--- a/src/RaygunAspireWebApp/Controllers/HomeController.cs
+++ b/src/RaygunAspireWebApp/Controllers/HomeController.cs
@@ -71,7 +71,7 @@ namespace RaygunAspireWebApp.Controllers
 
       return new ErrorInstanceRow
       {
-        Timestamp = fileInfo.LastWriteTime,
+        Timestamp = fileInfo.LastWriteTimeUtc,
         Name = decodedFilename,
         Id = id
       };

--- a/src/RaygunAspireWebApp/Controllers/HomeController.cs
+++ b/src/RaygunAspireWebApp/Controllers/HomeController.cs
@@ -62,7 +62,7 @@ namespace RaygunAspireWebApp.Controllers
         fileName = fileName.Substring(index + 1);
       }
 
-      string decodedFilename = HttpUtility.UrlDecode(fileName);
+      var decodedFilename = HttpUtility.UrlDecode(fileName);
 
       if (decodedFilename.EndsWith(".json"))
       {

--- a/src/RaygunAspireWebApp/RaygunAspireWebApp.csproj
+++ b/src/RaygunAspireWebApp/RaygunAspireWebApp.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
An exception occurs when the message is too long to be used as a file name. The limit should be 255 bytes. Since we URL encode the message, resulting in single-byte characters, this means we can check the character length of the file name before using it. If it's too long, we truncate it to fit.