### PR TITLE
Add support for CommunityToolkit

### DIFF
--- a/src/Raygun.Aspire.Hosting.Raygun/Raygun.Aspire.Hosting.Raygun.csproj
+++ b/src/Raygun.Aspire.Hosting.Raygun/Raygun.Aspire.Hosting.Raygun.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Raygun.Aspire.Hosting.Raygun/RaygunAspireWebAppBuilderExtensions.cs
+++ b/src/Raygun.Aspire.Hosting.Raygun/RaygunAspireWebAppBuilderExtensions.cs
@@ -14,5 +14,26 @@ namespace Aspire.Hosting.ApplicationModel
                     .ExcludeFromManifest()
                     .PublishAsContainer();
     }
+
+    public static IResourceBuilder<RaygunAspireWebAppResource> WithOllamaReference(this IResourceBuilder<RaygunAspireWebAppResource> builder, IResourceBuilder<IResourceWithConnectionString> source, string? model = null)
+    {
+      var resource = source.Resource;
+      var connectionName = resource.Name;
+
+      if (!string.IsNullOrEmpty(model))
+      {
+        builder.WithEnvironment("Ollama:Model", model);
+      }
+      return builder
+        .WithReference(source, "Ollama")
+          .WaitFor(source)
+        .WithEnvironment(context =>
+        {
+          if (!string.IsNullOrEmpty(model))
+          {
+            context.EnvironmentVariables["Ollama:Model"] = model;
+          }
+        });
+    }
   }
 }

--- a/src/RaygunAspireWebApp/Configuraiton/OllamaOptions.cs
+++ b/src/RaygunAspireWebApp/Configuraiton/OllamaOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace RaygunAspireWebApp.Configuraiton;
+
+public class OllamaOptions
+{
+    public string Model { get; set; } = Constants.AiModel;
+}

--- a/src/RaygunAspireWebApp/Program.cs
+++ b/src/RaygunAspireWebApp/Program.cs
@@ -1,5 +1,6 @@
 using Mindscape.Raygun4Net.AspNetCore;
 using OllamaSharp;
+using RaygunAspireWebApp.Configuraiton;
 using RaygunAspireWebApp.Hubs;
 
 namespace RaygunAspireWebApp
@@ -23,10 +24,15 @@ namespace RaygunAspireWebApp
       builder.Services.AddSignalR();
 
       var connectionString = builder.Configuration.GetConnectionString("Ollama");
+      var ollamaOptions = new OllamaOptions
+      {
+          Model = builder.Configuration["Ollama:Model"] ?? Constants.AiModel
+      };
+      builder.Services.AddSingleton(ollamaOptions);
+
       if (!string.IsNullOrWhiteSpace(connectionString))
       {
-        var modelName = builder.Configuration["Ollama:Model"] ?? Constants.AiModel;
-        builder.Services.Add(new ServiceDescriptor(typeof(IOllamaApiClient), new OllamaApiClient(connectionString.Replace("Endpoint=", string.Empty), modelName)));
+        builder.Services.Add(new ServiceDescriptor(typeof(IOllamaApiClient), new OllamaApiClient(connectionString.Replace("Endpoint=", string.Empty), ollamaOptions.Model)));
       }
 
       var app = builder.Build();

--- a/src/RaygunAspireWebApp/Program.cs
+++ b/src/RaygunAspireWebApp/Program.cs
@@ -25,7 +25,8 @@ namespace RaygunAspireWebApp
       var connectionString = builder.Configuration.GetConnectionString("Ollama");
       if (!string.IsNullOrWhiteSpace(connectionString))
       {
-        builder.Services.Add(new ServiceDescriptor(typeof(IOllamaApiClient), new OllamaApiClient(connectionString, Constants.AiModel)));
+        var modelName = builder.Configuration["Ollama:Model"] ?? Constants.AiModel;
+        builder.Services.Add(new ServiceDescriptor(typeof(IOllamaApiClient), new OllamaApiClient(connectionString, modelName)));
       }
 
       var app = builder.Build();

--- a/src/RaygunAspireWebApp/Program.cs
+++ b/src/RaygunAspireWebApp/Program.cs
@@ -26,7 +26,7 @@ namespace RaygunAspireWebApp
       if (!string.IsNullOrWhiteSpace(connectionString))
       {
         var modelName = builder.Configuration["Ollama:Model"] ?? Constants.AiModel;
-        builder.Services.Add(new ServiceDescriptor(typeof(IOllamaApiClient), new OllamaApiClient(connectionString, modelName)));
+        builder.Services.Add(new ServiceDescriptor(typeof(IOllamaApiClient), new OllamaApiClient(connectionString.Replace("Endpoint=", string.Empty), modelName)));
       }
 
       var app = builder.Build();


### PR DESCRIPTION
# Description

This adds better support for Ollama References.

- Provides an ability to specify a specific model to use
- Adds a new extension method for an Ollama Reference to make it easier to specify the Ollama reference. This ensures that we provide the appropriate ConnectionString name, and we can optionally provide a value for a Model to use
- Updates the web project so that we ensure that when using the Community Toolkit we remove the `Endpoint=` prefix which will result in an exception on startup.
- Updates to Aspire 9.0

## Issues
- closes #6 
- closes #7